### PR TITLE
Changes to the button size and centering of div elements

### DIFF
--- a/src/components/navBar.vue
+++ b/src/components/navBar.vue
@@ -52,7 +52,8 @@ export default {
             padding:  0;
         }
         .navbar-ul a {
-            font-size: 15pt;
+            font-size: 16pt;
+            margin: 10px;
         }
         .navbar-div {
             display: flex;
@@ -61,7 +62,8 @@ export default {
             position: absolute;
             top: 0;
 
-            width: 100%;
+            width: 90%;
+            padding: 0 5%;
             height: 100px;
         }
     }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -44,8 +44,10 @@ export default {
     bottom: 0.5rem;
   }
 
-  .title-div {
-
+  #title-div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   #start-button {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -54,4 +54,10 @@ export default {
     position: relative;
     top: 19vh
   }
+
+    @media screen and (max-width: 600px) {
+      #start-button {
+        width: 14rem;
+      }
+  }
 </style>


### PR DESCRIPTION
On the home page, the start coding button has been made smaller on screens lower than 600px in width, and the div for title elements now uses flexbox to center it's elements.